### PR TITLE
More library like and cleaner I2C lock utilization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+/libArchive
+/stubArchive

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pimoroni-trackball-circuitpy
 
-An simple, but effective CircuitPython-compatible library for using the Pimoroni Trackball module as a mouse. Based on [Pimoroni's official Python library](https://github.com/pimoroni/trackball-python), which is incompatible with CircuitPython.
+A simple, but effective CircuitPython-compatible library for using the Pimoroni Trackball module as a mouse. Based on [Pimoroni's official Python library](https://github.com/pimoroni/trackball-python), which is incompatible with CircuitPython.
 
 I don't have a totally clear understanding of how the Pimoroni Trackball works under the hood or why their official library does some of the things that it does. Anyway, I find the Trackball unsuitable for desktop OS use as it loses precision at higher acceleration/sensitivity value (set by the `multiplier` in the code.py file). Maybe someone smarter than me can fix this, but I suspect it's a hardware issue (e.g. the ball is too small to have the precision of a traditional trackball mouse).
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # pimoroni-trackball-circuitpy
-An adequate CircuitPython-compatible library for using the Pimoroni Trackball module as a mouse. Based on [Pimoroni's official Python library](https://github.com/pimoroni/trackball-python), which is incompatible with CircuitPython.
+
+An simple, but effective CircuitPython-compatible library for using the Pimoroni Trackball module as a mouse. Based on [Pimoroni's official Python library](https://github.com/pimoroni/trackball-python), which is incompatible with CircuitPython.
 
 I don't have a totally clear understanding of how the Pimoroni Trackball works under the hood or why their official library does some of the things that it does. Anyway, I find the Trackball unsuitable for desktop OS use as it loses precision at higher acceleration/sensitivity value (set by the `multiplier` in the code.py file). Maybe someone smarter than me can fix this, but I suspect it's a hardware issue (e.g. the ball is too small to have the precision of a traditional trackball mouse).
 
 ## Dependencies
-This code is tested to work with CircuitPython 7 and two of the libraries from the [Adafruit CircuitPython 7 bundle](https://circuitpython.org/libraries):
+
+This library code is tested to work with CircuitPython 7-10 and the required library from the [Adafruit CircuitPython bundle](https://circuitpython.org/libraries):
 
 - adafruit_bus_device
-- adafruit_hid
 
+The example code makes use of a few addition libraries, including:
+
+- adafruit_hid

--- a/code.py
+++ b/code.py
@@ -1,70 +1,37 @@
+import time
+
+import pimoroni_trackball_circuitpy as tb
 import usb_hid
-import board
-import busio
-from adafruit_bus_device.i2c_device import I2CDevice
 from adafruit_hid.mouse import Mouse
 
-I2C_ADDRESS = 0x0A
+old_coord = (0, 0, 0)
 
-REG_LED_RED = 0x00
-REG_LED_GRN = 0x01
-REG_LED_BLU = 0x02
-REG_LED_WHT = 0x03
-
-REG_LEFT = 0x04
-REG_RIGHT = 0x05
-REG_UP = 0x06
-REG_DOWN = 0x07
-
-# i2c @ address 0xA
 m = Mouse(usb_hid.devices)
-i2c = busio.I2C(board.SCL, board.SDA)
-device = I2CDevice(i2c, I2C_ADDRESS)
 
-# intensity of r,g,b,w LEDs from 0-100 e.g. set_leds(100,100,25,50)
-def set_leds(r,g,b,w):
-    device.write(bytes([REG_LED_RED, r & 0xff]))
-    device.write(bytes([REG_LED_GRN, g & 0xff]))
-    device.write(bytes([REG_LED_BLU, b & 0xff]))
-    device.write(bytes([REG_LED_WHT, w & 0xff]))
+tb.set_leds_red()
 
-def set_leds_purple(): set_leds(60,0,90,20)
-def set_leds_orange(): set_leds(99,63,8,0)
-def set_leds_yellow(): set_leds(100,85,6,0)
-def set_leds_white(): set_leds(0,0,0,100)
+multiplier = 9
 
-def i2c_rdwr(data, length=0):
-    """Write and optionally read I2C data."""
-    device.write(bytes(data))
+tb.set_leds_green()
 
-    if length > 0:
-        msg_r = bytearray(length)
-        device.readinto(msg_r)
-        return list(msg_r)
+lastSetTime = time.monotonic()
 
-    return []
+while True:
+    up, down, left, right, switch = tb.read()
 
-def read():
-    """Read up, down, left, right and switch data from trackball."""
-    left, right, up, down, switch = i2c_rdwr([REG_LEFT], 5)
-
-    switch = 129 == switch
-
-    return up, down, left, right, switch
-
-with device:
-    #set_leds(0,0,5,100)
-    set_leds_purple()
-
-    multiplier = 9
-
-    while True:
-        up, down, left, right, switch = read()
-
-        # Send movements and clicks to xte
-        if switch:
-            m.click(Mouse.LEFT_BUTTON)
-        else:
-            x = right - left
-            y = down - up
-            m.move(int(-x*multiplier), int(-y*multiplier), 0)
+    # Enact movements and clicks
+    if switch:
+        m.click(Mouse.LEFT_BUTTON)
+        print(f"BUTN↓")
+    else:
+        x = right - left
+        y = down - up
+        xmult = int(-x * multiplier)
+        ymult = int(-y * multiplier)
+        new_coord = (xmult, ymult, 0)
+        if new_coord != old_coord:
+            timeNow = time.monotonic()
+            if timeNow - lastSetTime > 2:
+                print(f"MOUS↑↓←→")
+                lastSetTime = time.monotonic()
+        m.move(xmult, ymult, 0)

--- a/lib/pimoroni_trackball_circuitpy.py
+++ b/lib/pimoroni_trackball_circuitpy.py
@@ -1,0 +1,83 @@
+import board
+import busio
+from adafruit_bus_device.i2c_device import I2CDevice
+
+I2C_ADDRESS = 0x0A
+
+REG_LED_RED = 0x00
+REG_LED_GRN = 0x01
+REG_LED_BLU = 0x02
+REG_LED_WHT = 0x03
+
+REG_LEFT = 0x04
+REG_RIGHT = 0x05
+REG_UP = 0x06
+REG_DOWN = 0x07
+
+# i2c @ address 0xA
+i2c = busio.I2C(board.SCL, board.SDA)
+device = I2CDevice(i2c, I2C_ADDRESS)
+
+
+# intensity of r,g,b,w LEDs from 0-100 e.g. set_leds(100,100,25,50)
+def set_leds(r, g, b, w):
+    while not i2c.try_lock():
+        pass
+    device.write(bytes([REG_LED_RED, r & 0xFF]))
+    device.write(bytes([REG_LED_GRN, g & 0xFF]))
+    device.write(bytes([REG_LED_BLU, b & 0xFF]))
+    device.write(bytes([REG_LED_WHT, w & 0xFF]))
+    i2c.unlock()
+
+
+def set_leds_cyan():
+    set_leds(0, 100, 100, 0)
+
+
+def set_leds_magenta():
+    set_leds(100, 0, 100, 0)
+
+
+def set_leds_yellow():
+    set_leds(100, 100, 0, 0)
+
+
+def set_leds_red():
+    set_leds(100, 0, 0, 0)
+
+
+def set_leds_green():
+    set_leds(0, 100, 0, 0)
+
+
+def set_leds_blue():
+    set_leds(0, 0, 100, 0)
+
+
+def set_leds_white():
+    set_leds(0, 0, 0, 100)
+
+
+def i2c_rdwr(data, length=0):
+    """Write and optionally read I2C data."""
+    while not i2c.try_lock():
+        pass
+    device.write(bytes(data))
+
+    if length > 0:
+        msg_r = bytearray(length)
+        device.readinto(msg_r)
+        i2c.unlock()
+        return list(msg_r)
+
+    i2c.unlock()
+    return []
+
+
+def read():
+    """Read up, down, left, right and switch data from trackball."""
+    left, right, up, down, switch = i2c_rdwr([REG_LEFT], 5)
+
+    switch = 129 == switch
+
+    return up, down, left, right, switch


### PR DESCRIPTION
The original version didn't work for me as a true library, so I re-worked it a bit so that it could be imported and called like a standard library and I2C functions that needed to request locks were doing so and then releasing them when done.

Feel free to merge it in if you would like, if simply for others who happen to stumble across this.
